### PR TITLE
Added service type from values.yaml

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 
 version: 0.3.1
 
-appVersion: "3.9.1"
+appVersion: "3.9.2"

--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -7,6 +7,6 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: 0.3.1
+version: 0.3.2
 
-appVersion: "3.9.2"
+appVersion: "3.9.1"

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.1](https://img.shields.io/badge/AppVersion-3.9.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.1](https://img.shields.io/badge/AppVersion-3.9.1-informational?style=flat-square)
 
 A Helm chart for a RabbitMQ cluster on Kubernetes
 

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ
 
-![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.1](https://img.shields.io/badge/AppVersion-3.9.1-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.1](https://img.shields.io/badge/AppVersion-3.9.1-informational?style=flat-square)
 
 A Helm chart for a RabbitMQ cluster on Kubernetes
 

--- a/charts/rabbitmq/templates/service.yaml
+++ b/charts/rabbitmq/templates/service.yaml
@@ -27,3 +27,4 @@ spec:
   {{- end }}
   selector:
     {{- include "rabbitmq.selectorLabels" . | nindent 4 }}
+  type: {{ .Values.service.type }}


### PR DESCRIPTION
Enables users to override the service type. So far, specifying the nodePort values did not suffice to expose the services through the host's port.