### PR TITLE
Rabbitmq 0.4.10 fails to start [error] Too short cookie string

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -7,6 +7,6 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: 0.4.10
+version: 0.4.11
 
 appVersion: "3.9.13"

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ
 
-![Version: 0.4.10](https://img.shields.io/badge/Version-0.4.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.13](https://img.shields.io/badge/AppVersion-3.9.13-informational?style=flat-square)
+![Version: 0.4.11](https://img.shields.io/badge/Version-0.4.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.9.13](https://img.shields.io/badge/AppVersion-3.9.13-informational?style=flat-square)
 
 ## Changelog
 
@@ -150,7 +150,7 @@ Section to define custom services
 | plugins | list | `[]` | List of additional RabbitMQ plugins that should be activated (see: [RabbitMQ plugins](https://www.rabbitmq.com/plugins.html)) |
 | authentication.user | string | `"guest"` | Initial user name |
 | authentication.password | string | `"guest"` | Initial password |
-| authentication.erlangCookie | string | `nil` | Erlang cookie (default: Random base64 value) |
+| authentication.erlangCookie | string | `nil` | Erlang cookie (MANDATORY) (Alternative: Set the environment variable ERLANG_COOKIE) |
 | clustering.rebalance | bool | `true` | Enable rebalance queues with master when new replica is created |
 | clustering.useLongName | bool | `true` | Use FQDN for RabbitMQ node names |
 

--- a/charts/rabbitmq/RELEASENOTES.md
+++ b/charts/rabbitmq/RELEASENOTES.md
@@ -7,4 +7,5 @@
 | 0.4.8 | 3.9.13 | Upgraded to RabbitMQ 3.9.13<br>Fixed ingress API detection<br>Implemented startupProbe support |
 | 0.4.9 | 3.9.13 | Fixed startupProbe |
 | 0.4.10 | 3.9.13 | Implemented support for extra secrets and advanced configuration capabilites |
+| 0.4.11 | 3.9.13 | Corrected chart documentation |
 | | | |

--- a/charts/rabbitmq/values.yaml
+++ b/charts/rabbitmq/values.yaml
@@ -208,7 +208,8 @@ plugins: []
 # Default user and erlang cookie
 # The erlang cookie is important for clustered or container based usage
 # Find more information about it at https://hub.docker.com/_/rabbitmq and https://www.rabbitmq.com/clustering.html#erlang-cookie
-# If erlang cookie is not provided in configuration a random value will be generated
+# The erlang cookie is a MANDATORY VALUE
+# Alternative is to set the environment variable ERLANG_COOKIE
 authentication:
   ## Initial user name
   user: "guest"
@@ -216,7 +217,7 @@ authentication:
   ## Initial password
   password: "guest"
 
-  ## Erlang cookie (mandatory)
+  ## Erlang cookie (MANDATORY)
   erlangCookie:
 
 # RabbitMQ specific configuration options described at https://www.rabbitmq.com/configure.html#config-items


### PR DESCRIPTION
Fixes #890