### PR TITLE
Remark42: init container command improvement

### DIFF
--- a/charts/remark42/Chart.yaml
+++ b/charts/remark42/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: "0.5.8"
+version: "0.5.9"
 
 appVersion: "v1.11.3"
 

--- a/charts/remark42/README.md
+++ b/charts/remark42/README.md
@@ -1,6 +1,6 @@
 # Remark42
 
-![Version: 0.5.8](https://img.shields.io/badge/Version-0.5.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.11.3](https://img.shields.io/badge/AppVersion-v1.11.3-informational?style=flat-square)
+![Version: 0.5.9](https://img.shields.io/badge/Version-0.5.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v1.11.3](https://img.shields.io/badge/AppVersion-v1.11.3-informational?style=flat-square)
 
 A Helm chart for Remark42 on Kubernetes
 
@@ -62,6 +62,8 @@ helm uninstall my-release
 | image.registry | string | `"docker.io"` | Image registry |
 | image.repository | string | `"umputun/remark42"` | Image name |
 | image.tag | string | `""` | Image tag |
+| initCommand | list | `["/bin/sh"]` | Init container command |
+| initArgs | list | `["-c","find /srvtmp -maxdepth 1 -type f -delete && rm -rf /srvtmp/web && cp -R /srv/* /srvtmp && mkdir -p /srvtmp/var"]` | Init container command args |
 | imagePullSecrets | list | `[]` | Image pull secrets |
 | strategy | object | `{}` | Pod deployment strategy |
 | startupProbe | object | `see values.yaml` | Startup probe configuration |

--- a/charts/remark42/RELEASENOTES.md
+++ b/charts/remark42/RELEASENOTES.md
@@ -23,4 +23,5 @@
 | 0.5.6 | v1.11.3 | Updated chart dependencies (redis 0.6.9) |
 | 0.5.7 | v1.11.3 | Updated chart dependencies (redis 0.6.10) |
 | 0.5.8 | v1.11.3 | Updated chart dependencies (redis 0.6.11) |
+| 0.5.9 | v1.11.3 | Added support for init container command and arguments (thx @IxDay) |
 | | | |

--- a/charts/remark42/templates/deployment.yaml
+++ b/charts/remark42/templates/deployment.yaml
@@ -45,8 +45,8 @@ spec:
           volumeMounts:
             - mountPath: /srvtmp
               name: remark-vol
-          command: [ "/bin/sh" ]
-          args: [ "-c", "find /srvtmp -maxdepth 1 -type f -delete && rm -rf /srvtmp/web && cp -R /srv/* /srvtmp && mkdir -p /srvtmp/var" ]
+          command: {{- toYaml .Values.initCommand | nindent 12}}
+          args: {{- toYaml .Values.initArgs | nindent 12}}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/charts/remark42/templates/deployment.yaml
+++ b/charts/remark42/templates/deployment.yaml
@@ -45,8 +45,8 @@ spec:
           volumeMounts:
             - mountPath: /srvtmp
               name: remark-vol
-          command: {{- toYaml .Values.initCommand | nindent 12}}
-          args: {{- toYaml .Values.initArgs | nindent 12}}
+          command: {{- toYaml .Values.initCommand | nindent 12 }}
+          args: {{- toYaml .Values.initArgs | nindent 12 }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.securityContext }}

--- a/charts/remark42/values.yaml
+++ b/charts/remark42/values.yaml
@@ -8,8 +8,11 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+## Init container command
 initCommand:
   - /bin/sh
+
+## Init container command args
 initArgs:
   - -c
   - find /srvtmp -maxdepth 1 -type f -delete && rm -rf /srvtmp/web && cp -R /srv/* /srvtmp && mkdir -p /srvtmp/var

--- a/charts/remark42/values.yaml
+++ b/charts/remark42/values.yaml
@@ -8,6 +8,12 @@ image:
   # Overrides the image tag whose default is the chart appVersion.
   tag: ""
 
+initCommand:
+  - /bin/sh
+initArgs:
+  - -c
+  - find /srvtmp -maxdepth 1 -type f -delete && rm -rf /srvtmp/web && cp -R /srv/* /srvtmp && mkdir -p /srvtmp/var
+
 ## Pull secrets and name override options
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
This patch makes the command from the init container configurable. It does not modify the previous behavior since it has been copy pasted in the values.yaml file.
You can change initCommand and initArgs to change the default behavior.

Fixes #1248

Also, I am not sure about the naming, feel free to point me to whatever format you want to enforce :smile: 
Thank you for your work on those charts