### PR TITLE
Remark42: add extra resources capability

### DIFF
--- a/charts/remark42/templates/_helpers.tpl
+++ b/charts/remark42/templates/_helpers.tpl
@@ -261,3 +261,16 @@ Commento settings via environment variables
 {{- end }}
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a value that contains template.
+Usage:
+{{ include "remark42.render" ( dict "value" .Values.path.to.the.Value "context" $) }}
+*/}}
+{{- define "remark42.render" -}}
+  {{- if typeIs "string" .value }}
+    {{- tpl .value .context }}
+  {{- else }}
+    {{- tpl (.value | toYaml) .context }}
+  {{- end }}
+{{- end -}}

--- a/charts/remark42/templates/extraressources.yaml
+++ b/charts/remark42/templates/extraressources.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraResources }}
+---
+{{- include "remark42.render" (dict "value" . "context" $) }}
+{{- end }}

--- a/charts/remark42/values.yaml
+++ b/charts/remark42/values.yaml
@@ -397,3 +397,21 @@ redis:
 
     ## the storage class name
     className:
+
+extraResources: []
+  # - |
+  #   apiVersion: projectcontour.io/v1
+  #   kind: HTTPProxy
+  #   metadata:
+  #     name: {{ include "remark42.fullname" . }}
+  #     namespace: {{ .Values.namespace | default .Release.Namespace }}
+  #     labels:
+  #       {{- include "remark42.labels" . | nindent 4 }}
+  #   spec:
+  #     ingressClassName: contour
+  #     virtualhost:
+  #       fqdn: {{.Values.settings.url | trimPrefix "http://"}}
+  #     routes:
+  #     - services:
+  #       - name: {{ include "remark42.fullname" . }}
+  #         port: {{ .Values.service.port }}


### PR DESCRIPTION
This commit introduces an extraResources value which is directly rendered as part of the chart like a regular Helm template. This allows users to add some Kubernetes object they might need as part of their cluster configuration.
I added in the comment an example of my use case because I use a different type of ingress and it is easier to configure it this way.

Closes: #1250