### PR TITLE
Add option to set Pod Topology Spread Constraints

### DIFF
--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -106,6 +106,7 @@ helm uninstall my-release
 | nodeSelector | object | `{}` | Deployment node selector |
 | podAnnotations | object | `{}` | Additional pod annotations |
 | podSecurityContext | object | `see values.yaml` | Pod security context |
+| podTopologySpreadConstraints | object | `{}` | Pod Toplology Spread Constraints |
 | securityContext | object | `see values.yaml` | Container security context |
 | env | list | `[]` | Additional container environmment variables (Redis server and Sentinel) |
 | args | list | `[]` | Additional container command arguments (Redis server) |

--- a/charts/redis/templates/statefulset.yaml
+++ b/charts/redis/templates/statefulset.yaml
@@ -52,6 +52,10 @@ spec:
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.podTopologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       initContainers:
         - name: {{ .Chart.Name }}-init
           {{- with .Values.securityContext }}

--- a/charts/redis/values.yaml
+++ b/charts/redis/values.yaml
@@ -32,6 +32,9 @@ podAnnotations: {}
 ## Pod management policy
 podManagementPolicy: OrderedReady
 
+## Pod TopologySpreadConstraints
+podTopologySpreadConstraints : {}
+
 ## Pod update strategy
 updateStrategyType: RollingUpdate
 


### PR DESCRIPTION
To manage to distribution of replicas in a multi zone environment, I added a value to specify Topology constraints in the redis deployments.

https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints

