### PR TITLE
Updated rabbitmq chart for RabbitMQ 3.13.6

### DIFF
--- a/charts/rabbitmq/Chart.yaml
+++ b/charts/rabbitmq/Chart.yaml
@@ -12,7 +12,7 @@ keywords:
   - messaging
   - rabbitmq
 
-version: "1.1.5"
+version: "1.1.6"
 
-appVersion: "3.13.5"
+appVersion: "3.13.6"
 icon: https://www.rabbitmq.com/img/rabbitmq-logo-with-name.svg

--- a/charts/rabbitmq/README.md
+++ b/charts/rabbitmq/README.md
@@ -1,6 +1,6 @@
 # RabbitMQ
 
-![Version: 1.1.5](https://img.shields.io/badge/Version-1.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.13.5](https://img.shields.io/badge/AppVersion-3.13.5-informational?style=flat-square)
+![Version: 1.1.6](https://img.shields.io/badge/Version-1.1.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.13.6](https://img.shields.io/badge/AppVersion-3.13.6-informational?style=flat-square)
 
 A Helm chart for a RabbitMQ HA-cluster on Kubernetes
 

--- a/charts/rabbitmq/RELEASENOTES.md
+++ b/charts/rabbitmq/RELEASENOTES.md
@@ -124,4 +124,5 @@
 | 1.1.3 | 3.13.3 | Upgraded to RabbitMQ 3.13.3 |
 | 1.1.4 | 3.13.4 | Upgraded to RabbitMQ 3.13.4 |
 | 1.1.5 | 3.13.5 | Upgraded to RabbitMQ 3.13.5 |
+| 1.1.6 | 3.13.6 | Upgraded to RabbitMQ 3.13.6 |
 | | | |


### PR DESCRIPTION
Normally I'd wait until you release a new version. This time however only the `amd64` image of RabbitMQ was pushed: https://hub.docker.com/layers/library/rabbitmq/3.13.5/images/sha256-c534306ad054bd05914bb218ee7b53cf8a5e6cb7d8d085ce5a349cff39982998?context=explore
3.13.6 doesn't have this issue and also pusses the `arm64` image alongside all the usual support platforms: https://hub.docker.com/layers/library/rabbitmq/3.13.6/images/sha256-02768f2e915808a8d6167b5aed372e881930108cac0b4a585c47e08f740b4c5e?context=explore