### PR TITLE
Add missing  environment variable for enabling smtp

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: "0.8.3"
+version: "0.8.4"
 
 appVersion: "6.0.4"
 

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -1,6 +1,6 @@
 # Graylog
 
-![Version: 0.8.3](https://img.shields.io/badge/Version-0.8.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.0.4](https://img.shields.io/badge/AppVersion-6.0.4-informational?style=flat-square)
+![Version: 0.8.4](https://img.shields.io/badge/Version-0.8.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 6.0.4](https://img.shields.io/badge/AppVersion-6.0.4-informational?style=flat-square)
 
 ## Changelog
 

--- a/charts/graylog/RELEASENOTES.md
+++ b/charts/graylog/RELEASENOTES.md
@@ -72,4 +72,5 @@
 | 0.8.1 | 6.0.2 | Updated chart for Graylog 6.0.2 |
 | 0.8.2 | 6.0.3 | Updated chart for Graylog 6.0.3 |
 | 0.8.3 | 6.0.4 | Updated chart for Graylog 6.0.4 |
+| 0.8.4 | 6.0.4 | Fixed missing variable to enable SMTP - thx @MMGeri |
 | | | |

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -116,7 +116,7 @@ Graylog settings via environment variables
 {{- end }}
 {{- if .Values.settings.smtp.enabled }}
 - name: GRAYLOG_TRANSPORT_EMAIL_ENABLED
-  value: {{- if .Values.settings.smtp.enabled | quote }}
+  value: {{ .Values.settings.smtp.enabled | quote }}
 {{- if .Values.settings.smtp.host }}
 - name: GRAYLOG_TRANSPORT_EMAIL_HOSTNAME
   value: {{ .Values.settings.smtp.host | quote }}

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -115,6 +115,8 @@ Graylog settings via environment variables
   value: {{ .Values.settings.journal.maxSize | quote }}
 {{- end }}
 {{- if .Values.settings.smtp.enabled }}
+- name: GRAYLOG_TRANSPORT_EMAIL_ENABLED
+  value: {{- if .Values.settings.smtp.enabled | quote }}
 {{- if .Values.settings.smtp.host }}
 - name: GRAYLOG_TRANSPORT_EMAIL_HOSTNAME
   value: {{ .Values.settings.smtp.host | quote }}


### PR DESCRIPTION
https://go2docs.graylog.org/5-0/downloading_and_installing_graylog/docker_installation.htm

GRAYLOG_TRANSPORT_EMAIL_ENABLED