### PR TITLE
MariaDB: Add option to set max emptyDir size

### DIFF
--- a/charts/mariadb/templates/statefulset.yaml
+++ b/charts/mariadb/templates/statefulset.yaml
@@ -323,7 +323,10 @@ spec:
           persistentVolumeClaim:
             claimName: {{ .persistentVolumeClaimName }}
         {{- else }}
-          emptyDir: {}
+          emptyDir:
+            {{- if .sizeLimit }}
+            sizeLimit: {{ .sizeLimit }}
+            {{- end }}
         {{- end }}
   {{- else }}
   {{- if $usedeployment }}

--- a/charts/mariadb/values.yaml
+++ b/charts/mariadb/values.yaml
@@ -266,6 +266,9 @@ storage:
   ## Keep a created Persistent volume claim when uninstalling the helm chart (only for option useDeployment: true)
   keepPvc: false
 
+  ## Set the sizeLimit of the emptyDir (only for option useDeployment: true)
+  sizeLimit:
+
   ## Additional storage annotations
   annotations: {}
 


### PR DESCRIPTION
This adds a new storage option (sizeLimit) to max the limit of the disk used by the emptyDir if the app is running in deployment (instead of Stateful set). Now it can consume unlimited amounts of storage potentially claiming everything the worker has got.