### PR TITLE
Add possibility for having resources limits/request in init container…

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -9,4 +9,4 @@ maintainers:
 
 version: "0.7.2"
 
-appVersion: "8.0.4"
+appVersion: "8.0.12"

--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -7,6 +7,6 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: "0.7.2"
+version: "0.7.3"
 
-appVersion: "8.0.12"
+appVersion: "8.0.13"

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -67,6 +67,7 @@ helm uninstall my-release
 | customStartupProbe | object | `{}` | Custom startup probe (overwrites default startup probe configuration) |
 | customLivenessProbe | object | `{}` | Custom liveness probe (overwrites default liveness probe configuration) |
 | customReadinessProbe | object | `{}` | Custom readiness probe (overwrites default readiness probe configuration) |
+| initResources | object | `{}` | Resource limits and requests for the default init container |
 | resources | object | `{}` | Resource limits and requests |
 | nodeSelector | object | `{}` | Deployment node selector |
 | customLabels | object | `{}` | Additional labels for Deployment or StatefulSet |

--- a/charts/mongodb/RELEASENOTES.md
+++ b/charts/mongodb/RELEASENOTES.md
@@ -104,4 +104,5 @@
 | 0.7.0 | 8.0.3 | Upgraded to MongoDB 8.0.3 |
 | 0.7.1 | 8.0.4 | Upgraded to MongoDB 8.0.4 |
 | 0.7.2 | 8.0.4 | Added support for loadBalancerSourceRanges |
+| 0.7.3 | 8.0.13 | Added optional resources section for the initContainer -thx @mirozoe |
 | | | |

--- a/charts/mongodb/templates/statefulset-arbiter.yaml
+++ b/charts/mongodb/templates/statefulset-arbiter.yaml
@@ -81,6 +81,10 @@ spec:
               name: keyfile-secret
             {{- end }}
           command: [ "/scripts/init.sh" ]
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.extraInitContainers }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mongodb/templates/statefulset-hidden.yaml
+++ b/charts/mongodb/templates/statefulset-hidden.yaml
@@ -94,6 +94,10 @@ spec:
               name: keyfile-secret
             {{- end }}
           command: [ "/scripts/init.sh" ]
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.extraInitContainers }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mongodb/templates/statefulset.yaml
+++ b/charts/mongodb/templates/statefulset.yaml
@@ -107,6 +107,10 @@ spec:
               name: keyfile-secret
             {{- end }}
           command: [ "/scripts/init.sh" ]
+          {{- with .Values.initResources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.extraInitContainers }}
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/mongodb/values.yaml
+++ b/charts/mongodb/values.yaml
@@ -85,6 +85,15 @@ resources: {}
   #   cpu: 100m
   #   memory: 128Mi
 
+## Resources limits and request used fro mongodb-init init container
+initResources: {}
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
 ## Custom startup probe (overwrites default startup probe)
 customStartupProbe: {}
 


### PR DESCRIPTION
…. and address couple of CVSs with update of MongoDB image.
1) Init container mongodb-init in STS doesn't support currently resources and needs to be updated afterwards with kustomize or so.
2) There are 2+ CVSs fixed in suggested mongodb image.