### PR TITLE
Upgrade chart to use Redis 8.6.3

### DIFF
--- a/charts/redis/Chart.yaml
+++ b/charts/redis/Chart.yaml
@@ -15,7 +15,7 @@ keywords:
 icon: https://redis.io/wp-content/uploads/2024/04/Logotype.svg
 
 # This is the chart version
-version: "2.3.2"
+version: "2.3.3"
 
 # This is the version number of the application being deployed.
-appVersion: "8.6.2"
+appVersion: "8.6.3"

--- a/charts/redis/README.md
+++ b/charts/redis/README.md
@@ -1,6 +1,6 @@
 # Redis
 
-![Version: 2.3.2](https://img.shields.io/badge/Version-2.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.6.2](https://img.shields.io/badge/AppVersion-8.6.2-informational?style=flat-square)
+![Version: 2.3.3](https://img.shields.io/badge/Version-2.3.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.6.3](https://img.shields.io/badge/AppVersion-8.6.3-informational?style=flat-square)
 
 ## Changelog
 

--- a/charts/redis/RELEASENOTES.md
+++ b/charts/redis/RELEASENOTES.md
@@ -106,4 +106,5 @@
 | 2.3.0 | 8.6.0 | Upgraded to Redis 8.6.0 |
 | 2.3.1 | 8.6.1 | Upgraded to Redis 8.6.1 |
 | 2.3.2 | 8.6.2 | Upgraded to Redis 8.6.2 |
+| 2.3.3 | 8.6.3 | Upgraded to Redis 8.6.3 |
 | | | |


### PR DESCRIPTION
This PR upgrades the redis version in the chart to 8.6.3.