### PR TITLE
Fixes Setting settings.smtp.useTls to false and ssl to true causes transport_email_use_tls to default to true. And causes a startup error.

### DIFF
--- a/charts/graylog/Chart.yaml
+++ b/charts/graylog/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: "0.13.0"
+version: "0.13.1"
 
 appVersion: "7.1.2"
 

--- a/charts/graylog/README.md
+++ b/charts/graylog/README.md
@@ -1,6 +1,6 @@
 # Graylog
 
-![Version: 0.13.0](https://img.shields.io/badge/Version-0.13.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.2](https://img.shields.io/badge/AppVersion-7.1.2-informational?style=flat-square)
+![Version: 0.13.1](https://img.shields.io/badge/Version-0.13.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 7.1.2](https://img.shields.io/badge/AppVersion-7.1.2-informational?style=flat-square)
 
 ## Changelog
 

--- a/charts/graylog/RELEASENOTES.md
+++ b/charts/graylog/RELEASENOTES.md
@@ -110,4 +110,5 @@
 | 0.12.3 | 7.0.5 | Updated chart for Graylog 7.0.5 |
 | 0.12.4 | 7.0.6 | Updated chart for Graylog 7.0.6 |
 | 0.13.0 | 7.1.2 | Updated chart for Graylog 7.1.2 |
+| 0.13.1 | 7.1.2 | Fixed useTls vs. useSSl default setting - thx @MMGeri |
 | | | |

--- a/charts/graylog/templates/_helpers.tpl
+++ b/charts/graylog/templates/_helpers.tpl
@@ -129,14 +129,10 @@ Graylog settings via environment variables
 - name: GRAYLOG_TRANSPORT_EMAIL_USE_AUTH
   value: {{ .Values.settings.smtp.useAuth | quote }}
 {{- end }}
-{{- if .Values.settings.smtp.useTls }}
 - name: GRAYLOG_TRANSPORT_EMAIL_USE_TLS
   value: {{ .Values.settings.smtp.useTls | quote }}
-{{- end }}
-{{- if .Values.settings.smtp.useSsl }}
 - name: GRAYLOG_TRANSPORT_EMAIL_USE_SSL
   value: {{ .Values.settings.smtp.useSsl | quote }}
-{{- end }}
 {{- if .Values.settings.smtp.subjectPrefix }}
 - name: GRAYLOG_TRANSPORT_EMAIL_SUBJECT_PREFIX
   value: {{ .Values.settings.smtp.subjectPrefix | quote }}


### PR DESCRIPTION
Fixes #1472