### PR TITLE
fix(mongodb): failing mongodb when using customConfig

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -7,6 +7,6 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: "0.7.11"
+version: "0.7.12"
 
 appVersion: "8.3.4"

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -1,6 +1,6 @@
 # MongoDB
 
-![Version: 0.7.11](https://img.shields.io/badge/Version-0.7.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.4](https://img.shields.io/badge/AppVersion-8.3.4-informational?style=flat-square)
+![Version: 0.7.12](https://img.shields.io/badge/Version-0.7.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.4](https://img.shields.io/badge/AppVersion-8.3.4-informational?style=flat-square)
 
 ## Changelog
 

--- a/charts/mongodb/RELEASENOTES.md
+++ b/charts/mongodb/RELEASENOTES.md
@@ -114,4 +114,5 @@
 | 0.7.9 | 8.0.26 | Upgraded to MongoDB 8.0.26, fixed PVC definition - thx @trandbert37 |
 | 0.7.10 | 8.3.4 | Upgraded mongodb to 8.3.4 |
 | 0.7.11 | 8.3.4 | Fixed README.md markdown formatting |
+| 0.7.12 | 8.3.4 | Fixed mongodb backoff restart when using customConfig |
 | | | |

--- a/charts/mongodb/templates/scripts.yaml
+++ b/charts/mongodb/templates/scripts.yaml
@@ -421,7 +421,7 @@ data:
     # Copy extra initialization scripts for ReplicaSet cluster
     cp /scripts/extra-*.sh /extrainitscripts
     echo "Copy custom configuration"
-    touch /configs/custom.conf
+    echo >/configs/custom.conf
     if [ -d /customconfig ]; then
       echo "Create custom mongodb config"
       cat /customconfig/* >>/configs/custom.conf


### PR DESCRIPTION
This fixes mongodb startup issues due to a malformed configuration file at `/etc/mongo/custom.conf`.

The reason for this is that `init.sh` (which is run by the initContainer) appends the contents of `.Values.customConfig` to `custom.conf`. This becomes an issue when `init.sh` runs multiple times, for example when the initContainer gets retried for whatever reason.

The resulting `custom.conf` will contain your `.Values.customConfig` twice and therefore can no longer be parsed by mongodb leading to infinite restart backoffs.

By truncating the file before appending to it, this issue is solved.

This behavior was seen in a deployment of mine and file truncation prior to appending the contents should fix the issue as this seems to be the only place where custom.conf gets modified.