### PR TITLE
fix(mongodb): regression 'unexpected "js-yaml.js" output while parsing config'

### DIFF
--- a/charts/mongodb/Chart.yaml
+++ b/charts/mongodb/Chart.yaml
@@ -7,6 +7,6 @@ type: application
 maintainers:
   - name: groundhog2k
 
-version: "0.7.12"
+version: "0.7.13"
 
 appVersion: "8.3.4"

--- a/charts/mongodb/README.md
+++ b/charts/mongodb/README.md
@@ -1,6 +1,6 @@
 # MongoDB
 
-![Version: 0.7.12](https://img.shields.io/badge/Version-0.7.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.4](https://img.shields.io/badge/AppVersion-8.3.4-informational?style=flat-square)
+![Version: 0.7.13](https://img.shields.io/badge/Version-0.7.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 8.3.4](https://img.shields.io/badge/AppVersion-8.3.4-informational?style=flat-square)
 
 ## Changelog
 

--- a/charts/mongodb/RELEASENOTES.md
+++ b/charts/mongodb/RELEASENOTES.md
@@ -115,4 +115,5 @@
 | 0.7.10 | 8.3.4 | Upgraded mongodb to 8.3.4 |
 | 0.7.11 | 8.3.4 | Fixed README.md markdown formatting |
 | 0.7.12 | 8.3.4 | Fixed mongodb backoff restart when using customConfig |
+| 0.7.13 | 8.3.4 | Fixed regression introduced in 0.7.12 (js-yaml.js) |
 | | | |

--- a/charts/mongodb/templates/scripts.yaml
+++ b/charts/mongodb/templates/scripts.yaml
@@ -421,7 +421,7 @@ data:
     # Copy extra initialization scripts for ReplicaSet cluster
     cp /scripts/extra-*.sh /extrainitscripts
     echo "Copy custom configuration"
-    echo >/configs/custom.conf
+    echo -n >/configs/custom.conf
     if [ -d /customconfig ]; then
       echo "Create custom mongodb config"
       cat /customconfig/* >>/configs/custom.conf


### PR DESCRIPTION
- fix(mongodb): regression 'unexpected "js-yaml.js" output while parsing config'

The change introduced in 1a77f8fb will lead to a regression during mongo
startup when *not* using `customConf`.

The file was previously empty and mongod happily used it.
The previous fix introduces a line break in the file - even when not
using `customConf` - which will result in this error message during init:

```plain
<... truncated ...>
***** EXTRA-INIT: Waiting until mongod is fully up and running
error: unexpected "js-yaml.js" output while parsing config:
***** EXTRA-INIT: Waiting for mongod...
<... truncated ...>
***** EXTRA-INIT: mongod is not running.. Stopping hard
```

This commit fixes that issue by ensuring no additional line breaks
are written to `custom.conf`.

Sorry for any inconvenience caused.

Related PR: https://github.com/groundhog2k/helm-charts/pull/1519
Commit introducing the regression: 1a77f8fb69079242d6744fdff9d75024c945f6b5

Signed-off-by: Christoph Hoopmann <choopm@0pointer.org>